### PR TITLE
Add logic to return 400 when cluster is empty

### DIFF
--- a/nsproxy/api_cluster_spec.go
+++ b/nsproxy/api_cluster_spec.go
@@ -28,6 +28,11 @@ func apiClusterSpecHandler(w http.ResponseWriter, r *http.Request, redisClient *
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 	}
-	redisClient.Del("tmp:cluster:index")
-	fmt.Fprintln(w, clusters)
+	if fmt.Sprintf("%x", clusters) == "[]" {
+		// empty reply, return 400
+		w.WriteHeader(http.StatusBadRequest)
+	} else {
+		redisClient.Del("tmp:cluster:index")
+		fmt.Fprintln(w, clusters)
+	}
 }


### PR DESCRIPTION
The API return for `/clusterspec` now matches that of `/hostspec` when there are no hosts/clusters registered.

This is a fix for https://github.com/unixvoid/nsproxy/issues/2